### PR TITLE
Disable wrapper for installed gems

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,7 +21,7 @@ do
 	sed -i'' '/signing_key/d' sensu-plugins-$PLUGIN.gemspec #We don't have the private key
 	gem build sensu-plugins-$PLUGIN.gemspec
 	gem uninstall -x sensu-plugins-$PLUGIN
-	gem install --no-ri --no-rdoc sensu-plugins-*.gem
+	gem install --no-ri --no-rdoc --no-wrapper sensu-plugins-*.gem
 	cd ..
 	rm -rf sensu-plugins-$PLUGIN-master
 done


### PR DESCRIPTION
It appears that sensu-plugin-mongodb ships with python script as executable, this lead to situation when gem installs wrapper for python script, which obviously doesn't work.

As this docker image supports dynamic gem installation there is no need to support versioning provided by gem wrapper.
