### PR TITLE
Added ability to use host's runtime system information for sensu-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,9 @@ ENV EXTENSION_DIR /etc/sensu/extensions
 ENV PLUGINS_DIR /etc/sensu/plugins
 ENV HANDLERS_DIR /etc/sensu/handlers
 
+#Config for gathering host metrics
+ENV HOST_DEV_DIR /dev
+ENV HOST_PROC_DIR /proc
+ENV HOST_SYS_DIR /sys
+
 ENTRYPOINT ["/bin/start"]

--- a/README.md
+++ b/README.md
@@ -47,23 +47,23 @@ ENV CHECK_DIR /etc/sensu/check.d
 ENV HANDLERS_DIR /etc/sensu/handlers
 ```
 
-If you want to use runtime system information for checks and metrics from container's *host* system (*not* from `sensu` container itself) you should:
+If you want `sensu-client` to use runtime system information for checks and metrics from container's *host* system (*not* from `sensu` container itself) you should:
 
 1. Define volumes to access host's filesystem from `sensu` container :
 
-	```
+  ```
   /dev:/host_dev/:ro
   /proc:/host_proc/:ro
   /sys:/host_sys/:ro
-	```
+  ```
 
 2. Redefine environment variables :
 
-	```
+  ```
   HOST_DEV_DIR: /host_dev
   HOST_PROC_DIR: /host_proc
   HOST_SYS_DIR: /host_sys
-	```
+  ```
 
 All Sensu plugins will be automatically configured to use these paths instead of default ones.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Dockerized Sensu
-============
+================
+
 This git repo provides [Sensu](https://sensuapp.org/) in a Docker container.
 
 Project: [https://github.com/sstarcher/docker-sensu]
@@ -11,19 +12,61 @@ Docker image: [https://registry.hub.docker.com/u/sstarcher/sensu/]
 [![](https://badge.imagelayers.io/sstarcher/sensu:latest.svg)](https://imagelayers.io/?images=sstarcher/sensu:latest 'Get your own badge on imagelayers.io')
 [![Docker Registry](https://img.shields.io/docker/pulls/sstarcher/sensu.svg)](https://registry.hub.docker.com/u/sstarcher/sensu)&nbsp;
 
-This is a base container for Sensu Core.  It contains sensu-api, sensu-client, sensu-server, but does not contain any plugins.
+This is a base container for Sensu Core. It contains `sensu-api`, `sensu-client`, `sensu-server`, but does *not* contain any plugins.
 
-Default configuration allows for local linkage to rabbitmq and redis, by using docker links.  If you need to reference external servers set the following variables as needed.
+Default configuration allows for local linkage to `rabbitmq` and `redis`, by using docker links. If you need to reference external servers set the following variables as needed.
 
-*Note
-Installed plugins for now can change without warning.  If you need a specific plugin installed either build a container based off of this one our use RUNTIME_INSTALL to ensure your plugins are installed.
-
-* Configuration
-The client by default only loads files from /etc/sensu/conf.d & the api and server load files from both conf.d and /etc/sensu/check.d
+This container can be configured to use runtime system information for checks and metrics from it's *host*.
 
 
+## Note
+
+Installed plugins for now can change without warning. If you need a specific plugin installed either build a container based off of this one our use `RUNTIME_INSTALL` to ensure your plugins are installed.
+
+
+## Configuration
+
+The client by default only loads files from `/etc/sensu/conf.d`.
+
+The API by default loads files from:
+
+- `/etc/sensu/conf.d`
+- `/etc/sensu/check.d`
+
+The server by default loads files from:
+
+- `/etc/sensu/conf.d`
+- `/etc/sensu/check.d`
+- `/etc/sensu/handlers`
+
+These defaults could be configured via environment variables:
+
+```
 ENV CONFIG_DIR /etc/sensu/conf.d
 ENV CHECK_DIR /etc/sensu/check.d
+ENV HANDLERS_DIR /etc/sensu/handlers
+```
+
+If you want to use runtime system information for checks and metrics from container's *host* system (*not* from `sensu` container itself) you should:
+
+1. Define volumes to access host's filesystem from `sensu` container :
+
+	```
+  /dev:/host_dev/:ro
+  /proc:/host_proc/:ro
+  /sys:/host_sys/:ro
+	```
+
+2. Redefine environment variables :
+
+	```
+  HOST_DEV_DIR: /host_dev
+  HOST_PROC_DIR: /host_proc
+  HOST_SYS_DIR: /host_sys
+	```
+
+All Sensu plugins will be automatically configured to use these paths instead of default ones.
+
 
 Dependencies:
   - Server
@@ -62,8 +105,7 @@ CLIENT_KEEPALIVE_HANDLER default
 ```
 
 
-
-An example docker-compose.yml file of running everything locally
+An example `docker-compose.yml` file of running everything locally:
 
 ```
 api:
@@ -97,7 +139,6 @@ rabbitmq:
   image: rabbitmq:3.5-management
 redis:
   image: redis
- ```
+```
 
-
-RUNTIME_INSTALL will allow you to install additional plugins from github during runtime
+`RUNTIME_INSTALL` will allow you to install additional plugins from github during runtime.

--- a/bin/start
+++ b/bin/start
@@ -6,8 +6,8 @@ set -e
 SENSU_SERVICE=${SENSU_SERVICE-$1}
 
 case "$SENSU_SERVICE" in
-   api)
-    DEPENDENCIES="rabbitmq redis"  
+  api)
+    DEPENDENCIES="rabbitmq redis"
     DIRS="$CONFIG_DIR,$CHECK_DIR"
     ;;&
   client)
@@ -16,7 +16,7 @@ case "$SENSU_SERVICE" in
     ;;&
   server)
     DEPENDENCIES="rabbitmq redis api"
-    DIRS="$CONFIG_DIR,$CHECK_DIR"
+    DIRS="$CONFIG_DIR,$CHECK_DIR,$HANDLERS_DIR"
     ;;&
   api|server|client)
     shopt -s nullglob #fixes null glob when no file exists
@@ -36,6 +36,11 @@ case "$SENSU_SERVICE" in
     do
       dockerize -template /etc/sensu/templates/$index.json.tmpl:$CONFIG_DIR/$index.json echo
     done
+
+    # use host (not container) dirs for checks and metrics
+    sed -i "s|/dev|$HOST_DEV_DIR|g" /opt/sensu/embedded/bin/*.rb
+    sed -i "s|/proc|$HOST_PROC_DIR|g" /opt/sensu/embedded/bin/*.rb
+    sed -i "s|/sys|$HOST_SYS_DIR|g" /opt/sensu/embedded/bin/*.rb
 
     dockerize sensu-$SENSU_SERVICE -d $DIRS -e $EXTENSION_DIR -L $LOG_LEVEL $OPTIONS
     ;;


### PR DESCRIPTION
Now `sensu-client` inside this container has ability to use host's runtime system information (_not_ from container itself) for checks and metrics. 
