### PR TITLE
Add GEM_SOURCES option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,6 @@ redis:
 ```
 
 `RUNTIME_INSTALL` will allow you to install additional plugins from github during runtime.
+
+`GEM_SOURCES` can be used to add additional gem sources (such as https://ruby.taobao.org/ for China).
+

--- a/bin/install
+++ b/bin/install
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e
 
+if [ -n "$GEM_SOURCES" ] && ! [ -e "/tmp/gem_sources_added" ]; then
+	for src in $(echo $GEM_SOURCES | tr ',' ' ')
+	do
+		echo "Adding gem source $src"
+		gem sources -a $src
+	done
+	touch /tmp/gem_sources_added
+fi
+
 for index in $@
 do
 	echo $index


### PR DESCRIPTION
It seems that the rubygems works very badly in China, so I added this option that allows other non-default gem sources to be given to the container.
