### PR TITLE
yaml2json: output the filenames

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -42,7 +42,7 @@ case "$SENSU_SERVICE" in
     process_template $CONFIG_DIR
     process_template $CHECK_DIR
     process_template $HANDLERS_DIR
-    
+
     for INDEX in $DEPENDENCIES
     do
       envtpl -in /etc/sensu/templates/${INDEX}.json.tmpl > $CONFIG_DIR/${INDEX}.json
@@ -54,8 +54,9 @@ case "$SENSU_SERVICE" in
     sed -i "s|/sys|$HOST_SYS_DIR|g" /opt/sensu/embedded/bin/*.rb
 
     find /etc/sensu -regex '.*\.ya?ml' | while read yamlFile; do
-      echo "Converting yaml to json"
+      echo -n "Converting yaml to json "
       jsonFile=$(echo ${yamlFile} | sed -r -e 's/\.ya?ml/.json/');
+      echo "${yamlFile} -> ${jsonFile}"
       yaml2json ${yamlFile} > ${jsonFile}
     done
 

--- a/bin/start
+++ b/bin/start
@@ -54,9 +54,11 @@ case "$SENSU_SERVICE" in
     sed -i "s|/sys|$HOST_SYS_DIR|g" /opt/sensu/embedded/bin/*.rb
 
     find /etc/sensu -regex '.*\.ya?ml' | while read yamlFile; do
-      echo -n "Converting yaml to json "
+      echo "Converting yaml to json"
       jsonFile=$(echo ${yamlFile} | sed -r -e 's/\.ya?ml/.json/');
-      echo "${yamlFile} -> ${jsonFile}"
+      if [[ "${LOG_LEVEL}" == "debug" ]]; then
+        echo "Converted ${yamlFile} to ${jsonFile}"
+      fi
       yaml2json ${yamlFile} > ${jsonFile}
     done
 


### PR DESCRIPTION
We run the "validate" step to test and make sure the yaml files are correctly formatted. It would be useful to see what files are being processed and fix ones that are failing.
