### PR TITLE
Plugin with @version cannot be installed

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -24,7 +24,7 @@ determine_params() {
 		PLUGIN="${Array[1]}"
 	fi
 
-	IFS="@"; declare -a PluginArray=("${PLUGIN}")
+	IFS="@"; declare -a PluginArray=($PLUGIN)
 	if [[ ${#PluginArray[@]} -eq 1 ]]; then
 		VERSION=$DEFAULT_PLUGINS_VERSION
 	else


### PR DESCRIPTION
I tried to workaround an issue in the latest version of the `influxdb` plugin with `RUNTIME_INSTALL=influxdb@962503e`, but unfortunately it does not work:

```
server-1 | 2016-05-13T02:34:11.152735464Z influxdb@962503e
server-1 | 2016-05-13T02:34:11.153618396Z 'sensu-plugins' 'influxdb@962503e' 'master'
server-1 | 2016-05-13T02:34:11.158163237Z /bin/install: line 84: /tmp/sensu-plugins-${PLUGIN}-${VERSION}/pid: ambiguous redirect
```

It seems that bash does not recognise arguments inside quotes:

```
root@client-1:/# A=1+2; IFS="+"; declare -a N=($A); echo ${N[0]}
1
root@client-1:/# A=1+2; IFS="+"; declare -a N=($A); echo ${N[1]}
2
root@client-1:/# A=1+2; IFS="+"; declare -a N=("$A"); echo ${N[1]}

root@client-1:/# A=1+2; IFS="+"; declare -a N=("$A"); echo ${N[0]}
1 2
```
