### PR TITLE
Calling the sensu process with exec

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -61,7 +61,7 @@ case "$SENSU_SERVICE" in
       OPTIONS="${OPTIONS} --print_config --validate_config"
     fi
 
-    sensu-$SENSU_SERVICE -d $DIRS -e $EXTENSION_DIR -L $LOG_LEVEL $OPTIONS
+    exec sensu-$SENSU_SERVICE -d $DIRS -e $EXTENSION_DIR -L $LOG_LEVEL $OPTIONS
     ;;
   *)
     echo 'Specify either api/server/client'


### PR DESCRIPTION
Since the sensu process was started directly from the script as a new process, sensu was not able to receive the SIGTERM from the docker stop. Making it exits unexpectedly.

Starting it with the bash builtin `exec` command (http://wiki.bash-hackers.org/commands/builtin/exec) the bash script is replaced by the sensu process, and it can receive the signals from docker correctly and shutdown gracefully.

I've already tested this solution on my containers e updated my local registry images.
Hope this change makes sense for you.
