### PR TITLE
remove build-essential package after the ruby gems have been installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN \
 	apt-get update && \
     apt-get install -y libxml2 libxml2-dev libxslt1-dev zlib1g-dev build-essential  && \
     gem install --no-ri --no-rdoc nokogiri yaml2json && \
-    apt-get remove -y libxml2-dev libxslt1-dev zlib1g-dev && \
+    apt-get remove -y libxml2-dev libxslt1-dev zlib1g-dev build-essential && \
+    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ ENV SENSU_VERSION=0.26.5-2
 RUN \
 	apt-get update && \
     apt-get install -y sensu=${SENSU_VERSION} && \
+    rm -rf /opt/sensu/embedded/lib/ruby/gems/2.3.0/{cache,doc}/* && \
+    find /opt/sensu/embedded/lib/ruby/gems/ -name "*.o" -delete && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PATH /opt/sensu/embedded/bin:$PATH
@@ -24,6 +26,8 @@ RUN \
     gem install --no-ri --no-rdoc nokogiri yaml2json && \
     apt-get remove -y libxml2-dev libxslt1-dev zlib1g-dev build-essential && \
     apt-get autoremove -y && \
+    rm -rf /opt/sensu/embedded/lib/ruby/gems/2.3.0/{cache,doc}/* && \
+    find /opt/sensu/embedded/lib/ruby/gems/ -name "*.o" -delete && \
     rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
The build-essentials Debian package is installed so that the ruby gems
can be compiled. This brings in gcc and numerous other packages that
are not needed in the final image. This patch removes the
build-essentials package, and its dependencies, after the ruby gems have
been compiled.

The output from `docker images` shows that the total image size goes
from 584.1 MB to 297.1 MB after this change.