### PR TITLE
Interpret backslash literal newlines for env-supplied SSL info

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -53,8 +53,8 @@ case "$SENSU_SERVICE" in
       fi
 
       mkdir -p /etc/sensu/ssl
-      echo "${RABBITMQ_SSL_CERT}" > /etc/sensu/ssl/cert.pem
-      echo "${RABBITMQ_SSL_KEY}" > /etc/sensu/ssl/key.pem
+      echo -e "${RABBITMQ_SSL_CERT}" > /etc/sensu/ssl/cert.pem
+      echo -e "${RABBITMQ_SSL_KEY}" > /etc/sensu/ssl/key.pem
     fi
 
     # use host (not container) dirs for checks and metrics


### PR DESCRIPTION
The -e allows me to pass multiline cert info in --env or --env-file arguments to docker run.  Without passing explicit \n the SSL load fails.

The escaped \n is necessary to pass multiline arguments to --env.  Ideally an --env-file could have actual newlines in cert info but docker's env-file handling is defective and the devs won't fix it [1], advising to use -e instead.

Thanks for this container!

[1] https://github.com/docker/docker/issues/12997#issuecomment-101083177
