### PR TITLE
Have VALIDATE_ONLY skip the install step

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -13,7 +13,7 @@ process_template(){
 
 if [[ "${VALIDATE_ONLY}" == "true" ]]; then
   echo "Skipping install step because the VALIDATE_ONLY flag is set"
-elif
+else
   /bin/install $RUNTIME_INSTALL
 fi
 

--- a/bin/start
+++ b/bin/start
@@ -11,7 +11,11 @@ process_template(){
   popd > /dev/null
 }
 
-/bin/install $RUNTIME_INSTALL
+if [[ "${VALIDATE_ONLY}" == "true" ]]; then
+  echo "Skipping install step because the VALIDATE_ONLY flag is set"
+elif
+  /bin/install $RUNTIME_INSTALL
+fi
 
 SENSU_SERVICE=${SENSU_SERVICE-$1}
 


### PR DESCRIPTION
There is a use case in our CI environments where we need to quickly verify the configuration files. Because we must specify api/server/client we need to run a test against each type (e.g. /bin/start api). This infeasible when we have to run the /bin/install step as it would require us to run through the install process for api, client, and server.

Please advise if there is another way to quickly verify the configuration files.