### PR TITLE
Do not install dev tools if there is no need

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [[ $# -eq 0 ]] ; then
+	exit
+fi
+
 if [ -n "$GEM_SOURCES" ] && ! [ -e "/tmp/gem_sources_added" ]; then
 	for src in $(echo $GEM_SOURCES | tr ',' ' ')
 	do

--- a/bin/start
+++ b/bin/start
@@ -66,7 +66,7 @@ case "$SENSU_SERVICE" in
       sed -i "s|/dev|$HOST_DEV_DIR|g" /opt/sensu/embedded/bin/*.rb
       sed -i "s|/proc|$HOST_PROC_DIR|g" /opt/sensu/embedded/bin/*.rb
       sed -i "s|/sys|$HOST_SYS_DIR|g" /opt/sensu/embedded/bin/*.rb
-    fi    
+    fi
 
     find /etc/sensu -regex '.*\.ya?ml' | while read yamlFile; do
       jsonFile=$(echo ${yamlFile} | sed -r -e 's/\.ya?ml/.json/');


### PR DESCRIPTION
Do not run the install script on startup if no runtime plugins are specified. Speeds up startup