### PR TITLE
clair scanned on 20170425 - Found 0 vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM ubuntu:zesty-20170411
 MAINTAINER Shane Starcher <shanestarcher@gmail.com>
 
 ENV SENSU_VERSION=0.29.0-7
@@ -8,7 +8,7 @@ RUN \
     apt-get update &&\
     apt-get install -y curl ca-certificates apt-transport-https &&\
     curl -s https://sensu.global.ssl.fastly.net/apt/pubkey.gpg | apt-key add - &&\
-    echo "deb     https://sensu.global.ssl.fastly.net/apt jessie main" > /etc/apt/sources.list.d/sensu.list &&\
+    echo "deb     https://sensu.global.ssl.fastly.net/apt xenial main" > /etc/apt/sources.list.d/sensu.list &&\
     apt-get update &&\
     apt-get install -y sensu=${SENSU_VERSION} &&\
     rm -rf /opt/sensu/embedded/lib/ruby/gems/2.3.0/{cache,doc}/* && \


### PR DESCRIPTION
deployed to DevTest tonight without issue. Same size (178MB) w/o vulns :)

For reference, here's what Clair (https://github.com/coreos/clair) found:

https://www.dropbox.com/s/p8laf16r0v8w64r/sensu.latest.vulns?dl=0

against sstarcher/sensu:latest.