### PR TITLE
Provide CLIENT_KEEPALIVE_WARNING/CRITICAL options for keepalive thresholds

### DIFF
--- a/templates/client.json.tmpl
+++ b/templates/client.json.tmpl
@@ -14,6 +14,10 @@
     ],
     {{end}}
     "keepalive": {
+      "thresholds": {
+         "warning": {{ default .CLIENT_KEEPALIVE_WARNING 120 }},
+         "critical": {{ default .CLIENT_KEEPALIVE_CRITICAL 180 }}
+      },
       "handler": {{ default "default" .CLIENT_KEEPALIVE_HANDLER | quote }}
     }
   }


### PR DESCRIPTION
The default values provided are the ones according to:
https://sensuapp.org/docs/0.24/reference/clients.html#thresholds-attributes