### PR TITLE
Improvements of /bin/install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ ENV DEFAULT_PLUGINS_REPO=sensu-plugins \
     #Common Config
     RUNTIME_INSTALL='' \
     PARALLEL_INSTALLATION=1 \
+    UNINSTALL_BUILD_TOOLS=1 \
     LOG_LEVEL=warn \
     CONFIG_FILE=/etc/sensu/config.json \
     CONFIG_DIR=/etc/sensu/conf.d \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ ENV DEFAULT_PLUGINS_REPO=sensu-plugins \
     REDIS_RECONNECT_ON_ERROR=false \
     #Common Config
     RUNTIME_INSTALL='' \
+    PARALLEL_INSTALLATION=1 \
     LOG_LEVEL=warn \
     CONFIG_FILE=/etc/sensu/config.json \
     CONFIG_DIR=/etc/sensu/conf.d \

--- a/README.md
+++ b/README.md
@@ -122,4 +122,6 @@ You can use `docker-compose.yaml` to run everything locally.
 
 Multiple plugins will be installed in parallel. However, if fetching and compiling too many dependencies at the same time cause issues, set `PARALLEL_INSTALLATION` to 0.
 
+If you want to keep the installed build tools and the apt cache, set `UNINSTALL_BUILD_TOOLS` to 0.
+
 `GEM_SOURCES` can be used to add additional gem sources (such as https://ruby.taobao.org/ for China).

--- a/README.md
+++ b/README.md
@@ -120,4 +120,6 @@ You can use `docker-compose.yaml` to run everything locally.
 
 `RUNTIME_INSTALL` will allow you to install additional plugins from github during runtime.  The install format is USERNAME/repo:TAG.  The default USERNAME is sensu-plugins and the default TAG is master.  In place of a TAG a full git sha may be used.
 
+Multiple plugins will be installed in parallel. However, if fetching and compiling too many dependencies at the same time cause issues, set `PARALLEL_INSTALLATION` to 0.
+
 `GEM_SOURCES` can be used to add additional gem sources (such as https://ruby.taobao.org/ for China).

--- a/bin/install
+++ b/bin/install
@@ -73,7 +73,7 @@ if [ ${PARALLEL_INSTALLATION:-1} = 1 ]; then
 	done
 fi
 
-tooling_uninstall
+[ ${UNINSTALL_BUILD_TOOLS:-1} = 1 ] && tooling_uninstall
 
 if [ "$FAIL" -ne "0" ]; then
 	exit $FAIL

--- a/bin/install
+++ b/bin/install
@@ -57,15 +57,21 @@ install() {
 
 tooling_install
 
-# Launch all plugins installations in parallel
+# Launch all plugins installations in parallel, if requested
 for index in "$@"; do
-	install "$index" &
+	if [ ${PARALLEL_INSTALLATION:-1} = 1 ]; then
+		install "$index" &
+	else
+		install "$index"
+	fi
 done
 
 FAIL=0
-for job in $(jobs -p); do
-	wait $job || let "FAIL=+1"
-done
+if [ ${PARALLEL_INSTALLATION:-1} = 1 ]; then
+	for job in $(jobs -p); do
+		wait $job || let "FAIL=+1"
+	done
+fi
 
 tooling_uninstall
 

--- a/bin/install
+++ b/bin/install
@@ -1,20 +1,20 @@
 #!/bin/bash
 set -e
 
-if [[ $# -eq 0 ]] ; then
+if [[ $# -eq 0 ]]; then
 	exit
 fi
 
 if [ -n "$GEM_SOURCES" ] && ! [ -e "/tmp/gem_sources_added" ]; then
-	for src in $(echo $GEM_SOURCES | tr ',' ' ')
-	do
+	for src in $(echo $GEM_SOURCES | tr "," " "); do
 		echo "Adding gem source $src"
 		gem sources -a $src
 	done
 	touch /tmp/gem_sources_added
 fi
 
-DEBIAN_TOOLING='libxml2 libxml2-dev libxslt1-dev zlib1g-dev build-essential'
+DEBIAN_TOOLING="libxml2 libxml2-dev libxslt1-dev zlib1g-dev build-essential"
+
 tooling_install() {
 	apt-get update
 	apt-get install -y $DEBIAN_TOOLING
@@ -37,7 +37,7 @@ determine_params() {
 	VERSION=${VERSION:-${DEFAULT_PLUGINS_VERSION}}
 }
 
-install(){
+install() {
 	determine_params "$1"
 	echo -e "Downloading \t $REPO/$PLUGIN:$VERSION"
 	curl -Ls https://github.com/$REPO/sensu-plugins-$PLUGIN/archive/$VERSION.tar.gz > "$PLUGIN"
@@ -45,7 +45,7 @@ install(){
 
 	echo -e "Building \t $REPO/$PLUGIN:$VERSION"
 	cd sensu-plugins-$PLUGIN-$VERSION
-	sed -i'' '/signing_key/d' sensu-plugins-$PLUGIN.gemspec #We don't have the private key
+	sed -i"" "/signing_key/d" sensu-plugins-$PLUGIN.gemspec #We don't have the private key
 	gem build sensu-plugins-$PLUGIN.gemspec > /dev/null
 
 	echo -e "Installing \t $REPO/$PLUGIN:$VERSION"
@@ -56,19 +56,19 @@ install(){
 }
 
 tooling_install
+
 # Launch all plugins installations in parallel
-for index in "$@"
-do
+for index in "$@"; do
 	install "$index" &
 done
 
 FAIL=0
-for job in `jobs -p`
-do
-    wait $job || let "FAIL=+1"
+for job in $(jobs -p); do
+	wait $job || let "FAIL=+1"
 done
 
 tooling_uninstall
+
 if [ "$FAIL" -ne "0" ]; then
 	exit $FAIL
 fi


### PR DESCRIPTION
Two additions to the /bin/install script which are particularly useful when building containers based on this one:

* Non-parallel mode (a parallel installation of multiple plugins might cause rate or resource limits)
* Option to keep the APT cache, in case more stuff needs to be built.