### PR TITLE
Base on ruby2.4 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:zesty-20170411
+FROM ruby:2.4-slim-stretch
 MAINTAINER Shane Starcher <shanestarcher@gmail.com>
 
 ARG SENSU_VERSION=1.2.0-1
@@ -7,13 +7,24 @@ ARG ENVTPL_VERSION=0.2.3
 
 RUN \
     apt-get update &&\
-    apt-get install -y curl ca-certificates apt-transport-https &&\
+    apt-get install -y --no-install-recommends curl ca-certificates apt-transport-https gnupg locales &&\
+    # Setup default locale & cleanup unneeded
+    echo "LC_ALL=en_US.UTF-8" >> /etc/environment &&\
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen &&\
+    echo "LANG=en_US.UTF-8" > /etc/locale.conf &&\
+    locale-gen en_US.UTF-8 &&\
+    find /usr/share/i18n/locales ! -name en_US -type f -exec rm -v {} + &&\
+    find /usr/share/i18n/charmaps ! -name UTF-8.gz -type f -exec rm -v {} + &&\
+    # Install Sensu
     curl -s https://sensu.global.ssl.fastly.net/apt/pubkey.gpg | apt-key add - &&\
-    echo "deb     https://sensu.global.ssl.fastly.net/apt xenial main" > /etc/apt/sources.list.d/sensu.list &&\
+    echo "deb https://sensu.global.ssl.fastly.net/apt stretch main" > /etc/apt/sources.list.d/sensu.list &&\
     apt-get update &&\
     apt-get install -y sensu=${SENSU_VERSION} &&\
-    rm -rf /opt/sensu/embedded/lib/ruby/gems/2.4.0/{cache,doc}/* && \
-    find /opt/sensu/embedded/lib/ruby/gems/ -name "*.o" -delete && \
+    rm -rf /opt/sensu/embedded/lib/ruby/gems/2.4.0/{cache,doc}/* &&\
+    find /opt/sensu/embedded/lib/ruby/gems/ -name "*.o" -delete &&\
+    # Cleanup debian
+    apt-get remove -y gnupg &&\
+    apt-get autoremove -y &&\
     rm -rf /var/lib/apt/lists/* &&\
     # Install dumb-init
     curl -Ls https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64.deb > dumb-init.deb &&\
@@ -23,18 +34,20 @@ RUN \
     curl -Ls https://github.com/arschles/envtpl/releases/download/${ENVTPL_VERSION}/envtpl_linux_amd64 > /usr/local/bin/envtpl &&\
     chmod +x /usr/local/bin/envtpl &&\
     gem install --no-document yaml2json &&\
-    mkdir -p /etc/sensu/conf.d /etc/sensu/check.d /etc/sensu/extensions /etc/sensu/plugins /etc/sensu/handlers
+    mkdir -p /etc/sensu/conf.d /etc/sensu/check.d /etc/sensu/extensions /etc/sensu/plugins /etc/sensu/handlers &&\
+    # Undo world writable bundle directory, see https://github.com/docker-library/ruby/issues/74
+    chmod -R o-w /usr/local/bundle
 
 COPY templates /etc/sensu/templates
 COPY bin /bin/
 
 ENV DEFAULT_PLUGINS_REPO=sensu-plugins \
     DEFAULT_PLUGINS_VERSION=master \
-    #Client Config
+    # Client Config
     CLIENT_SUBSCRIPTIONS=all,default \
     CLIENT_BIND=127.0.0.1 \
     CLIENT_DEREGISTER=true \
-    #Transport
+    # Transport
     TRANSPORT_NAME=redis \
     RABBITMQ_PORT=5672 \
     RABBITMQ_HOST=rabbitmq \
@@ -50,7 +63,7 @@ ENV DEFAULT_PLUGINS_REPO=sensu-plugins \
     REDIS_DB=0 \
     REDIS_AUTO_RECONNECT=true \
     REDIS_RECONNECT_ON_ERROR=false \
-    #Common Config
+    # Common Config
     RUNTIME_INSTALL='' \
     PARALLEL_INSTALLATION=1 \
     UNINSTALL_BUILD_TOOLS=1 \
@@ -61,11 +74,16 @@ ENV DEFAULT_PLUGINS_REPO=sensu-plugins \
     EXTENSION_DIR=/etc/sensu/extensions \
     PLUGINS_DIR=/etc/sensu/plugins \
     HANDLERS_DIR=/etc/sensu/handlers \
-    #Config for gathering host metrics
+    # Config for gathering host metrics
     HOST_DEV_DIR=/dev \
     HOST_PROC_DIR=/proc \
     HOST_SYS_DIR=/sys \
-    PATH=/opt/sensu/embedded/bin:$PATH
+    # Include sensu installation into path
+    PATH=/opt/sensu/embedded/bin:$PATH \
+    # Set default locale & collations
+    LC_ALL=en_US.UTF-8 \
+    # -W0 avoids sensu client output to be spoiled with ruby 2.4 warnings
+    RUBYOPT=-W0
 
 EXPOSE 4567
 VOLUME ["/etc/sensu/conf.d"]

--- a/bin/start
+++ b/bin/start
@@ -61,12 +61,13 @@ case "$SENSU_SERVICE" in
       echo -e "${RABBITMQ_SSL_KEY}" > /etc/sensu/ssl/key.pem
     fi
 
-    # use host (not container) dirs for checks and metrics
-    if compgen -G "/opt/sensu/embedded/bin/*.rb" > /dev/null; then
-      sed -i "s|/dev|$HOST_DEV_DIR|g" /opt/sensu/embedded/bin/*.rb
-      sed -i "s|/proc|$HOST_PROC_DIR|g" /opt/sensu/embedded/bin/*.rb
-      sed -i "s|/sys|$HOST_SYS_DIR|g" /opt/sensu/embedded/bin/*.rb
-    fi
+    # For checks which need access to the host's /dev, /proc or /sys filesystem,
+    # adjust the checks to the directories mounted from the host
+    for dir in $(gem env gempath | sed -e 's/:/ /g'); do
+      if compgen -G "${dir}/*.rb" > /dev/null; then
+        sed -i -e "s|/dev|$HOST_DEV_DIR|g" -e "s|/proc|$HOST_PROC_DIR|g" -e "s|/sys|$HOST_SYS_DIR|g" ${dir}/*.rb
+      fi
+    done
 
     find /etc/sensu -regex '.*\.ya?ml' | while read yamlFile; do
       jsonFile=$(echo ${yamlFile} | sed -r -e 's/\.ya?ml/.json/');


### PR DESCRIPTION
Ubuntu Zesty is end of life and not supported anymore. Also, having a distribution with Ruby 2.3 and Sense with embedded 2.4 causes issues when additional gems are required for plugins.

This PR uses the official ruby:2.4 image based on the latest Debian (`stretch`), and updates the entry point script to consider all ruby gem paths properly.

I also took the chance to simplify the Dockerfile layering. For my understanding, there's not much benefit of multiple `RUN` steps in term of reduced build time or less updates of lower layers, compared to the overhead of more layers.