### PR TITLE
Check for availability of packages for Stretch

### DIFF
--- a/latest.sh
+++ b/latest.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -e
-curl -s http://sensu.global.ssl.fastly.net/apt/pool/jessie/main/s/sensu/ | grep - | cut -d'>' -f2 | cut -d'_' -f2 | sort | tail -n1
+curl -s http://sensu.global.ssl.fastly.net/apt/pool/stretch/main/s/sensu/ | grep - | cut -d'>' -f2 | cut -d'_' -f2 | sort | tail -n1


### PR DESCRIPTION
Obviously, Jessie is no longer the base Debian system behind image ruby:2.4-stretch-slim, so check the right packages availability.